### PR TITLE
Create publish_and_tag.yml

### DIFF
--- a/.github/workflows/publish_and_tag.yml
+++ b/.github/workflows/publish_and_tag.yml
@@ -1,0 +1,44 @@
+# Workflow to send master to pypi and tag  the branch:
+# You need to edit FOLDER_WITH_VERSION with the folder that has the __version__ value. 
+
+name: master to pypi with comments and tag
+
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+env:
+  FOLDER_WITH_VERSION: continuousflex
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+        pip install scipion-pyworkflow 
+        pip install scipion-em
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/* -c "${{ secrets.PYPI_COMMENT }}"
+    - name: Get version and tag
+      run: |
+        export PACKAGE_VERSION=$(python -c "import $FOLDER_WITH_VERSION; print('VERSION', 'v'+$FOLDER_WITH_VERSION.__version__)" | grep VERSION | sed "s/VERSION //g")
+        git tag $PACKAGE_VERSION
+        git push origin $PACKAGE_VERSION

--- a/continuousflex/__init__.py
+++ b/continuousflex/__init__.py
@@ -31,6 +31,7 @@ import pyworkflow.utils as pwutils
 getXmippPath = pwem.Domain.importFromPlugin("xmipp3.base", 'getXmippPath')
 
 _logo = "logo.png"
+__version__ = "3.0.0b1"
 
 class Plugin(pwem.Plugin):
     _homeVar = CONTINUOUSFLEX_HOME

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
+from continuousflex import __version__
 
 here = path.abspath(path.dirname(__file__))
 
@@ -69,7 +70,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.7',  # Required
+    version=__version__,  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
Hi @MohamadHarastani this will automate:

1.- tagging the code with continuousflex.__version__
2.- Releasing the plugin to pypi using the right comment (scipion-3.0) nowadays.
3.- Standarize versioning between pipy and module, Both uses now a single source.
4.- Scipion will log the version of the plugin

1 and 2 only happen if you push changes to master branch. I've also created a support branch to have scipion2.0 plugin code, in case any action is needed.

One important thing. As it is now it will work, but the credentials are taken from scipion-em organiazationwhich corresponds to scipion account.

To deploy as you or Slavica to pypi, you need to define 2 secrets here( https://github.com/scipion-em/scipion-em-continuousflex/settings/secrets):
PYPI_USERNAME 
PYPI_PASSWORD

Matching either your pypi credentials or Slavica's
