### PR TITLE
JMK: viewer_nma works for SetOfNormalModes

### DIFF
--- a/continuousflex/viewers/viewer_nma.py
+++ b/continuousflex/viewers/viewer_nma.py
@@ -161,8 +161,11 @@ def createDistanceProfilePlot(protocol, modeNumber):
 
 
 def createVmdView(protocol, modeNumber):
-    vmdFile = protocol._getExtraPath("animations", "animated_mode_%03d.vmd"
-                                     % modeNumber)
+    if isinstance(protocol, SetOfNormalModes):
+        vmdFile = os.path.dirname(os.path.dirname(protocol[1].getModeFile())) + "/extra/animations/animated_mode_%03d.vmd" % modeNumber
+    else:
+        vmdFile = protocol._getExtraPath("animations", "animated_mode_%03d.vmd"
+                                        % modeNumber)
     return VmdView('-e "%s"' % vmdFile)
 
 def createVmdNmwizView(protocol, modeNumber):


### PR DESCRIPTION
- The SetOfNormalModes object is added to the targets of viewer_nma and the form and functions are modified to get paths when using one. This allows us to use it with ones from ProDy too.

- The VMD viewer for the Continuous Flex animation is also made conditional depending on whether the required files exist.

- A new VMD viewer option is added for NMD files conditional on if they are found. A SetOfNormalModes from a ProDy protocol will have them automatically and they can be added to a Continuous Flex SetOfNormalModes (and the associated protocol) by using the ProDy mode viewer first.