### PR TITLE
JMK - convert pdb - correct location of pwem Volume

### DIFF
--- a/continuousflex/protocols/pdb/protocol_convert_pdb.py
+++ b/continuousflex/protocols/pdb/protocol_convert_pdb.py
@@ -120,7 +120,7 @@ class FlexProtConvertPdb(em.protocols.ProtInitialVolume):
         self.runJob(program, args)
 
     def createOutput(self):
-        volume = em.Volume()
+        volume = em.objects.Volume()
         volume.setSamplingRate(self.sampling.get())
         volume.setFileName(self._getVolName())
         self._defineOutputs(outputVolume=volume)


### PR DESCRIPTION
Without this fix, the convert pdb to volume protocol fails with the following error:
```
  File "/mnt/c/Users/james/code/scipion3_new/scipion-em-plugins/scipion-em-continuousflex/continuousflex/protocols/pdb/protocol_convert_pdb.py", line 123, in createOutput
    volume = em.Volume()
AttributeError: module 'pwem' has no attribute 'Volume'
[31mProtocol failed: module 'pwem' has no attribute 'Volume'[0m
```

With the fix, everything completes fine.