### PR TITLE
Fix for PyCuda conflicts

### DIFF
--- a/continuousflex/__init__.py
+++ b/continuousflex/__init__.py
@@ -138,6 +138,13 @@ class Plugin(pwem.Plugin):
                        neededProgs=['mpif90'],
                        target="genesis", default=False)
 
+        try:
+            env.addPipModule('pycuda', version='2020.1', default=True)
+            env.addPipModule('farneback3d', version='0.1.3', default=True)
+        except:
+            print('Installation of PyCuda and Farneback-3D was not successful,'
+                  ' you will not be able to use Cuda related programs')
+
 
 files_dictionary = {'pdb': 'pdb/AK.pdb', 'particles': 'particles/img.stk', 'vol': 'volumes/AK_LP10.vol',
                     'precomputed_atomic': 'gold/images_WS_atoms.xmd',

--- a/continuousflex/viewers/viewer_heteroflow_dimred.py
+++ b/continuousflex/viewers/viewer_heteroflow_dimred.py
@@ -46,7 +46,6 @@ from pwem.viewers.viewer_chimera import Chimera
 
 from joblib import load, dump
 from continuousflex.protocols.utilities.spider_files3 import open_volume, save_volume
-import farneback3d
 import matplotlib.pyplot as plt
 from pwem.emlib.image import ImageHandler
 
@@ -352,6 +351,7 @@ class FlexDimredHeteroFlowViewer(ProtocolViewer):
         browser.show()
 
     def _generateAnimation(self):
+        import farneback3d
         prot = self.protocol
         # This is not getting the file correctly, we are workingaround it:
         # projectorFile = prot.getProjectorFile()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 matplotlib
-farneback3d
-pycuda==2020.1
 #scikit-image
 mrcfile


### PR DESCRIPTION
@ Pablo, I am adding you as a reviewer since you previously reported that continuousflex is causing cuda related issues with other users.
The logic:
This pull request makes farneback3d and pycuda optional dependencies by removing them from the requirements and "trying" to install them while installing the plugin. If Cuda is not available, or there is any problem in it (not added properly to the path etc.), then ContinuousFlex will install without it.
farneback and pycuda are imported inside other functions instead of being on the top to avoid failing (failure will only happen when trying to use the protocols that require them).