### PR TITLE
LAPACK ARPACK in continuousflex-org + MD-NMMD-Genesis 2.0 +Fix pdb dim red viewer 

### DIFF
--- a/continuousflex/__init__.py
+++ b/continuousflex/__init__.py
@@ -98,7 +98,7 @@ class Plugin(pwem.Plugin):
                        "cmake --build . ; "
                         "cp lib/* %s"
                        %
-                       (lapack_version, env.getTmpFolder(),env.getLibFolder()),
+                       (env.getTmpFolder(),lapack_version,env.getLibFolder()),
                        [env.getLibFolder()+"/liblapack.so",
                         env.getLibFolder()+"/liblapacke.so",
                         env.getLibFolder()+"/libblas.so"])])

--- a/continuousflex/__init__.py
+++ b/continuousflex/__init__.py
@@ -94,9 +94,9 @@ class Plugin(pwem.Plugin):
             neededProgs=['gfortran'],
             commands=[("cd %s/lapack-%s ; "
                        "mkdir BUILD ; cd BUILD ; "
-                       "cmake -DBUILD_SHARED_LIBS:BOOL=ON -DLAPACKE:BOOL=ON .. ; "
-                       "cmake --build . ; "
-                        "cp lib/* %s"
+                         "cmake -DBUILD_SHARED_LIBS:BOOL=ON -DLAPACKE:BOOL=ON .. ; "
+                         "cmake --build . ; "
+                          "cp lib/* %s"
                        %
                        (env.getTmpFolder(),lapack_version,env.getLibFolder()),
                        [env.getLibFolder()+"/liblapack.so",

--- a/continuousflex/__init__.py
+++ b/continuousflex/__init__.py
@@ -34,6 +34,7 @@ import subprocess
 
 _logo = "logo.png"
 __version__ = "3.1.4"
+MD_NMMD_GENESIS_VERSION = "1.1"
 
 class Plugin(pwem.Plugin):
     _homeVar = CONTINUOUSFLEX_HOME
@@ -45,7 +46,7 @@ class Plugin(pwem.Plugin):
     def _defineVariables(cls):
         cls._defineEmVar(CONTINUOUSFLEX_HOME, 'xmipp')
         cls._defineEmVar(NMA_HOME,'nma')
-        cls._defineEmVar(GENESIS_HOME, 'MD-NMMD-Genesis-2.0')
+        cls._defineEmVar(GENESIS_HOME, 'MD-NMMD-Genesis-'+MD_NMMD_GENESIS_VERSION)
         cls._defineVar(VMD_HOME,'/usr/local/lib/vmd')
         cls._defineVar(MATLAB_HOME, '~/programs/Matlab')
 
@@ -141,9 +142,9 @@ class Plugin(pwem.Plugin):
                                   % env.getLibFolder(), 'nma_diag_arpack')],
                        neededProgs=['gfortran'], default=True)
 
-        target_branch = "nmmd_image_merge"
+        target_branch = "merge_genesis_1.4"
 
-        env.addPackage('MD-NMMD-Genesis', version='2.0', deps=[lapack],
+        env.addPackage('MD-NMMD-Genesis', version=MD_NMMD_GENESIS_VERSION, deps=[lapack],
                        buildDir='MD-NMMD-Genesis', tar="void.tgz",
                        commands=[('git clone -b %s https://github.com/continuousflex-org/MD-NMMD-Genesis.git . ; '
                                   'autoreconf -fi ;'

--- a/continuousflex/protocols/protocol_align_pdbs.py
+++ b/continuousflex/protocols/protocol_align_pdbs.py
@@ -182,7 +182,7 @@ class FlexProtAlignPdb(ProtAnalysis3D):
             # add to MD
             trans_mat = np.zeros((4,4))
             trans_mat[:3,:3] = rot_mat
-            trans_mat[:,3] = tran
+            trans_mat[:,3][:3] = tran
             rot, tilt, psi,shftx, shfty, shftz = matrix2eulerAngles(trans_mat)
             index = alignXMD.addObject()
             alignXMD.setValue(md.MDL_ANGLE_ROT, rot, index)

--- a/continuousflex/protocols/protocol_nmmd_refine.py
+++ b/continuousflex/protocols/protocol_nmmd_refine.py
@@ -144,7 +144,7 @@ class ProtNMMDRefine(ProtGenesis):
             # add to MD
             trans_mat = np.zeros((4,4))
             trans_mat[:3,:3] = rot_mat
-            trans_mat[:,3] = tran
+            trans_mat[:,3][:3] = tran
             rot, tilt, psi,shftx, shfty, shftz = matrix2eulerAngles(trans_mat)
             index = alignXMD.addObject()
             alignXMD.setValue(md.MDL_ANGLE_ROT, rot, index)

--- a/continuousflex/viewers/tk_dimred.py
+++ b/continuousflex/viewers/tk_dimred.py
@@ -16,6 +16,7 @@ class PCAWindowDimred(TrajectoriesWindow, ClusteringWindow):
     def __init__(self, **kwargs):
         TrajectoriesWindow.__init__(self, **kwargs)
         self.saveClusterCallback = kwargs.get('saveClusterCallback', None)
+        self.saveCallback = kwargs.get('saveCallback', None)
         self.numberOfPoints = kwargs.get('numberOfPoints', 10)
 
         self._alpha=self.alpha

--- a/continuousflex/viewers/viewer_pdb_dimred.py
+++ b/continuousflex/viewers/viewer_pdb_dimred.py
@@ -211,8 +211,7 @@ class FlexProtPdbDimredViewer(ProtocolViewer):
     def viewPcaSinglularValues(self, paramName):
         pca = load(self.protocol._getExtraPath('pca_pickled.joblib'))
         fig = plt.figure('PCA singlular values')
-        plt.stem(pca.singular_values_)
-        plt.xticks(np.arange(0, len(pca.singular_values_), 1))
+        plt.stem(np.arange(1, len(pca.singular_values_)+1), pca.singular_values_)
         plt.show()
         pass
 
@@ -426,6 +425,11 @@ class FlexProtPdbDimredViewer(ProtocolViewer):
         if set(classID) != {0}:
             np.savetxt(animationRoot + 'clusters.txt', np.array(classID))
             saved.append('clusters.txt')
+
+        try :
+            self.trajectoriesWindow.plotter.figure.savefig(animationRoot + 'figure.png',dpi=500)
+        except:
+            pass
 
         if len(saved) != 0:
             self.trajectoriesWindow.showInfo('Successfully saved : %s.' % str(saved))

--- a/continuousflex/viewers/viewer_pdb_dimred.py
+++ b/continuousflex/viewers/viewer_pdb_dimred.py
@@ -249,7 +249,7 @@ class FlexProtPdbDimredViewer(ProtocolViewer):
         # Get animation root
         animation = self.trajectoriesWindow.getClusterName()
         animationPath = prot._getExtraPath('animation_%s' % animation)
-        if not os.path.isdir:
+        if not os.path.isdir(animationPath):
             cleanPath(animationPath)
             makePath(animationPath)
         animationRoot = os.path.join(animationPath, '')
@@ -410,7 +410,7 @@ class FlexProtPdbDimredViewer(ProtocolViewer):
     def _saveAnimation(self, tkWindow):
         # get cluster name
         animationPath = self.protocol._getExtraPath("animation_" + tkWindow.getClusterName())
-        if not os.path.isdir:
+        if not os.path.isdir(animationPath):
             cleanPath(animationPath)
             makePath(animationPath)
         animationRoot = os.path.join(animationPath, '')


### PR DESCRIPTION
**LAPACK ARPACK in continuousflex-org** 

I created a repo called continuousflex-lib with a new version of LAPACK (3.10.1) and the same version of ARPACK
The new lapack needs CMAKE 3.0 or higher (2014), not by default on CentOS 7 (you need to yum install cmake3 and do a symbolic link cmake->cmake3), by default on Ubuntu 18.0 and 20.0

Please try uninstalling all continuousflex (remove arpack, lapack, blas, lapacke from lib folder, remove content of tmp file, remove MD-NMMD-Genesis ) and reinstall and run all tests. I did it on my machines (Ubuntu 20.0, Ubuntu 18.0, Centos 7 ) 

**MD-NMMD-Genesis 2.0** 

New version of GENESIS (1.7.1, previously 1.4.0)


**Fix pdb dim red viewer** 

Bugs of saving trajectory and opening VMD

