### PR TITLE
fixed installation of farneback

### DIFF
--- a/continuousflex/__init__.py
+++ b/continuousflex/__init__.py
@@ -109,12 +109,12 @@ class Plugin(pwem.Plugin):
 
         def getCondaInstallation(version, txtfile):
             installationCmd = cls.getCondaActivationCmd()
-            # If nvcc is not in the path, don't install Optical Flow or DeepLearning Libraries
-            if os.popen('which nvcc').read() == "":
-                config_path = continuousflex.__path__[0] + '/conda_noCuda.yaml'
-            else:
+            config_path = continuousflex.__path__[0] + '/conda_noCuda.yaml'
+            installationCmd += 'conda env create -f {} --prefix .'.format(config_path)
+            # If nvcc is in the path, install Optical Flow and DeepLearning Libraries
+            if os.popen('which nvcc').read() is not None:
                 config_path = continuousflex.__path__[0] + '/conda.yaml'
-            installationCmd += 'conda env create -f {} --prefix . --force'.format(config_path)
+                installationCmd += "&& conda env update --name . --file={}".format(config_path)
             installationCmd += ' && touch {}'.format(txtfile)
             return installationCmd
 

--- a/continuousflex/__init__.py
+++ b/continuousflex/__init__.py
@@ -114,7 +114,7 @@ class Plugin(pwem.Plugin):
             # If nvcc is in the path, install Optical Flow and DeepLearning Libraries
             if os.popen('which nvcc').read() is not None:
                 config_path = continuousflex.__path__[0] + '/conda.yaml'
-                installationCmd += "&& conda env update --name . --file={}".format(config_path)
+                installationCmd += "&& conda env update --prefix . --file={}".format(config_path)
             installationCmd += ' && touch {}'.format(txtfile)
             return installationCmd
 

--- a/continuousflex/__init__.py
+++ b/continuousflex/__init__.py
@@ -110,7 +110,7 @@ class Plugin(pwem.Plugin):
         def getCondaInstallation(version, txtfile):
             installationCmd = cls.getCondaActivationCmd()
             config_path = continuousflex.__path__[0] + '/conda_noCuda.yaml'
-            installationCmd += 'conda env create -f {} --prefix .'.format(config_path)
+            installationCmd += 'conda env create -f {} --prefix . --force'.format(config_path)
             # If nvcc is in the path, install Optical Flow and DeepLearning Libraries
             if os.popen('which nvcc').read() is not None:
                 config_path = continuousflex.__path__[0] + '/conda.yaml'

--- a/continuousflex/conda.yaml
+++ b/continuousflex/conda.yaml
@@ -18,4 +18,4 @@ dependencies:
       - git+https://github.com/scipion-em/scipion-pyworkflow.git@master
       - scipion-em
       - numpy==1.23.0
-      - git+https://github.com/MohamadHarastani/farneback3d.git
+      - farneback3d==0.1.4

--- a/continuousflex/conda.yaml
+++ b/continuousflex/conda.yaml
@@ -5,12 +5,12 @@ dependencies:
   - python=3.8
   - pip:
       - setuptools==59.5.0
-      - torch==1.10.1
+      - torch==1.13.1
       - starfile
       - matplotlib
       - mrcfile
       - umap-learn
-      - torchvision==0.11.2
+      - torchvision==0.14.1
       - tensorboard==2.8.0
       - tqdm==4.64.0
       - protobuf==3.20.3

--- a/continuousflex/conda_noCuda.yaml
+++ b/continuousflex/conda_noCuda.yaml
@@ -4,6 +4,7 @@ dependencies:
   - pip
   - python=3.8
   - pip:
+      - setuptools==59.5.0
       - umap-learn
       - scipion-em
       - tqdm==4.64.0


### PR DESCRIPTION
This fix does the following:
To install farneback-3d, we need to make sure that an older version of setuptools is installed beforehand. Since yaml files are unordered dictionaries, we were getting (at least on Centos) the installation of farneback3d before setuptools. In this fix, I force the right order by first installing conda_noCuda.yaml, then updating the environment by the remaining libraries of conda.yaml.