### PR TITLE
Jmk improvements

### DIFF
--- a/continuousflex/protocols/protocol_genesis.py
+++ b/continuousflex/protocols/protocol_genesis.py
@@ -45,6 +45,7 @@ import re
 class FlexProtGenesis(EMProtocol):
     """ Protocol to perform MD/NMMD simulation based on GENESIS. """
     _label = 'MD-NMMD-Genesis'
+    _possibleOutputs = {'outputPDBs': SetOfPDBs}
 
     def __init__(self, **kwargs):
         EMProtocol.__init__(self, **kwargs)

--- a/continuousflex/protocols/protocol_pdb_dimred.py
+++ b/continuousflex/protocols/protocol_pdb_dimred.py
@@ -26,8 +26,9 @@ from pyworkflow.protocol.params import (PointerParam, EnumParam, IntParam)
 from pwem.protocols import ProtAnalysis3D
 from pyworkflow.utils.path import makePath
 from pyworkflow.protocol import params
-from pwem.emlib import MetaData, MDL_ENABLED, MDL_NMA_MODEFILE,MDL_ORDER
-from pwem.objects import SetOfNormalModes, AtomStruct
+from pwem.emlib import (MetaData, MDL_ENABLED, MDL_NMA_MODEFILE, MDL_ORDER,
+                        MDL_NMA_EIGENVAL)
+from pwem.objects import SetOfPrincipalComponents, AtomStruct, Float
 from .convert import rowToMode
 from xmipp3.base import XmippMdRow
 from continuousflex.protocols.utilities.genesis_utilities import numpyArr2dcd,dcd2numpyArr
@@ -174,8 +175,9 @@ class FlexProtDimredPdb(ProtAnalysis3D):
             pdb.coords = pca.mean_.reshape(pdbs_matrix.shape[1] // 3, 3)
             pdb.write_pdb(self._getPath("atoms.pdb"))
             makePath(pathPC)
-            matrix = pca.components_.reshape(self.reducedDim.get(),pdbs_matrix.shape[1]//3,3)
-            self.writePrincipalComponents(prefix=pathPC, matrix = matrix)
+            matrix = pca.components_.reshape(self.reducedDim.get(), pdbs_matrix.shape[1]//3,3)
+            self.eigenvalues = list(pca.explained_variance_)
+            self.writePrincipalComponents(prefix=pathPC, matrix=matrix)
             np.savetxt(self.getOutputMatrixFile(),Y)
 
         elif self.method.get() == REDUCE_METHOD_UMAP:
@@ -200,10 +202,11 @@ class FlexProtDimredPdb(ProtAnalysis3D):
                 mdOut.setValue(MDL_NMA_MODEFILE, modefile, objId)
                 mdOut.setValue(MDL_ORDER, i + 1, objId)
                 mdOut.setValue(MDL_ENABLED, 1, objId)
+                #mdOut.setValue(MDL_NMA_EIGENVAL, Float(self.eigenvalues[i]), objId)
             mdOut.write(self._getPath("modes.xmd"))
 
             # Sqlite object
-            pcSet =SetOfNormalModes(filename=self._getPath("modes.sqlite"))
+            pcSet = SetOfPrincipalComponents(filename=self._getPath("modes.sqlite"))
             row = XmippMdRow()
             for objId in mdOut:
                 row.readFromMd(mdOut, objId)


### PR DESCRIPTION
Using SetOfPrincipalComponents is more informative and I think had some other benefit (maybe something to do with how ProDy loads it), but I can't remember what. It inherits from SetOfNormalModes and doesn't have any of its own methods or attributes, so is functionally the same.

Having fractional contributions as eigenvalues in the Scipion object can be useful though.

I also found a use for possible outputs for the genesis protocol for setting up the next protocol downstream