### PR TITLE
replace force flag

### DIFF
--- a/continuousflex/__init__.py
+++ b/continuousflex/__init__.py
@@ -110,7 +110,7 @@ class Plugin(pwem.Plugin):
         def getCondaInstallation(version, txtfile):
             installationCmd = cls.getCondaActivationCmd()
             config_path = continuousflex.__path__[0] + '/conda_noCuda.yaml'
-            installationCmd += 'conda env create -f {} --prefix . --force'.format(config_path)
+            installationCmd += 'conda env create -f {} --prefix . --yes'.format(config_path)
             # If nvcc is in the path, install Optical Flow and DeepLearning Libraries
             if os.popen('which nvcc').read() is not None:
                 config_path = continuousflex.__path__[0] + '/conda.yaml'


### PR DESCRIPTION
Old conda still has -y/--yes flag, while in the new one --force is deprecated. So it should be a safe fix.
Closes #192 